### PR TITLE
Deploy keys + Sync commit + RegExp src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL "repository"="http://github.com/wei/git-sync"
 LABEL "homepage"="http://github.com/wei/git-sync"
 LABEL "maintainer"="Wei He <github@weispot.com>"
 
-RUN apk add --no-cache git openssh-client && \
+RUN apk add --no-cache git openssh-client bash && \
   echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 ADD *.sh /

--- a/README.md
+++ b/README.md
@@ -13,15 +13,21 @@ A GitHub Action for syncing between two independent repositories using **force p
 
 > Always make a full backup of your repo (`git clone --mirror`) before using this action.
 
-- Generate different ssh keys for both source and destination repositories, leave passphrase empty
+- Either generate different ssh keys for both source and destination repositories or use the same one for both, leave passphrase empty (note that GitHub deploy keys must be unique)
 
 ```sh
 $ ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
 ```
 
-- In GitHub add the public keys (`key_name.pub`) to _Settings > Deploy keys_ for each repository respectively, allow write access for the destination repository
+- In GitHub, either:
 
-- Add both the private keys to _Settings > Secrets_ for the repository containing the action (`SOURCE_SSH_PRIVATE_KEY` and `DESTINATION_SSH_PRIVATE_KEY`)
+  - add the unique public keys (`key_name.pub`) to _Repo Settings > Deploy keys_ for each repository respectively and allow write access for the destination repository
+
+  or
+
+  - add the single public key (`key_name.pub`) to _Personal Settings > SSH keys_
+
+- Add the private key(s) to _Repo > Settings > Secrets_ for the repository containing the action (`SSH_PRIVATE_KEY` or `SOURCE_SSH_PRIVATE_KEY` and `DESTINATION_SSH_PRIVATE_KEY`)
 
 ### GitHub Actions
 
@@ -36,17 +42,18 @@ jobs:
       - name: repo-sync
         uses: wei/git-sync@v2
         with:
-          source_repo: "git@github.com:username/repository.git"
+          source_repo: "username/repository"
           source_branch: "main"
           destination_repo: "git@github.com:org/repository.git"
           destination_branch: "main"
-          source_ssh_private_key: ${{ secrets.SOURCE_SSH_PRIVATE_KEY }}
-          destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }}
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }} # optional
+          source_ssh_private_key: ${{ secrets.SOURCE_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
+          destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
 ```
 
 ##### Alternative using https
 
-The `source_ssh_private_key` and `destination_ssh_private_key` can be omitted if using authenticated https urls.
+The `ssh_private_key`, `source_ssh_private_key` and `destination_ssh_private_key` can be omitted if using authenticated https urls.
 
 ```yml
 source_repo: "https://username:personal_access_token@github.com/username/repository.git"
@@ -73,7 +80,7 @@ destination_branch: "refs/tags/*"
 ### Docker
 
 ```sh
-$ docker run --rm -e "SOURCE_SSH_PRIVATE_KEY=$(cat ~/.ssh/id_rsa)" $(docker build -q .) \
+$ docker run --rm -e "SSH_PRIVATE_KEY=$(cat ~/.ssh/id_rsa)" $(docker build -q .) \
   $SOURCE_REPO $SOURCE_BRANCH $DESTINATION_REPO $DESTINATION_BRANCH
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,86 @@
 # Git Sync
 
-A GitHub Action for syncing between two independent repositories using **force push**. 
-
+A GitHub Action for syncing between two independent repositories using **force push**.
 
 ## Features
- * Sync branches between two GitHub repositories
- * Sync branches to/from a remote repository
- * GitHub action can be triggered on a timer or on push
- * To sync with current repository, please checkout [Github Repo Sync](https://github.com/marketplace/actions/github-repo-sync)
 
+- Sync branches between two GitHub repositories
+- Sync branches to/from a remote repository
+- GitHub action can be triggered on a timer or on push
+- To sync with current repository, please checkout [Github Repo Sync](https://github.com/marketplace/actions/github-repo-sync)
 
 ## Usage
 
-Always make a full backup of your repo (`git clone --mirror`) before using this action.
+> Always make a full backup of your repo (`git clone --mirror`) before using this action.
+
+- Generate different ssh keys for both source and destination repositories, leave passphrase empty
+
+```sh
+$ ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
+```
+
+- In GitHub add the public keys (`key_name.pub`) to _Settings > Deploy keys_ for each repository respectively, allow write access for the destination repository
+
+- Add both the private keys to _Settings > Secrets_ for the repository containing the action (`SOURCE_SSH_PRIVATE_KEY` and `DESTINATION_SSH_PRIVATE_KEY`)
 
 ### GitHub Actions
-```
-# File: .github/workflows/repo-sync.yml
+
+```yml
+# .github/workflows/repo-sync.yml
 
 on: push
 jobs:
   repo-sync:
     runs-on: ubuntu-latest
     steps:
-    - name: repo-sync
-      uses: wei/git-sync@v2
-      with:
-        source_repo: ""
-        source_branch: ""
-        destination_repo: ""
-        destination_branch: ""
-        ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: repo-sync
+        uses: wei/git-sync@v2
+        with:
+          source_repo: "git@github.com:username/repository.git"
+          source_branch: "main"
+          destination_repo: "git@github.com:org/repository.git"
+          destination_branch: "main"
+          source_ssh_private_key: ${{ secrets.SOURCE_SSH_PRIVATE_KEY }}
+          destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }}
 ```
-`ssh_private_key` can be omitted if using authenticated HTTPS repo clone urls like `https://username:access_token@github.com/username/repository.git`.
+
+##### Alternative using https
+
+The `source_ssh_private_key` and `destination_ssh_private_key` can be omitted if using authenticated https urls.
+
+```yml
+source_repo: "https://username:personal_access_token@github.com/username/repository.git"
+```
 
 #### Advanced: Sync all branches
 
 To Sync all branches from source to destination, use `source_branch: "refs/remotes/source/*"` and `destination_branch: "refs/heads/*"`. But be careful, branches with the same name including `master` will be overwritten.
 
+```yml
+source_branch: "refs/remotes/source/*"
+destination_branch: "refs/heads/*"
+```
+
 #### Advanced: Sync all tags
 
 To Sync all tags from source to destination, use `source_branch: "refs/tags/*"` and `destination_branch: "refs/tags/*"`. But be careful, tags with the same name will be overwritten.
 
-### Docker
+```yml
+source_branch: "refs/tags/*"
+destination_branch: "refs/tags/*"
 ```
-docker run --rm -e "SSH_PRIVATE_KEY=$(cat ~/.ssh/id_rsa)" $(docker build -q .) \
+
+### Docker
+
+```sh
+$ docker run --rm -e "SOURCE_SSH_PRIVATE_KEY=$(cat ~/.ssh/id_rsa)" $(docker build -q .) \
   $SOURCE_REPO $SOURCE_BRANCH $DESTINATION_REPO $DESTINATION_BRANCH
 ```
 
 ## Author
+
 [Wei He](https://github.com/wei) _github@weispot.com_
 
-
 ## License
+
 [MIT](https://wei.mit-license.org)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A GitHub Action for syncing between two independent repositories using **force p
 - Sync branches to/from a remote repository
 - GitHub action can be triggered on a timer or on push
 - To sync with current repository, please checkout [Github Repo Sync](https://github.com/marketplace/actions/github-repo-sync)
+- Optional _git-sync_ commit with a specific user
 
 ## Usage
 
@@ -43,12 +44,15 @@ jobs:
         uses: wei/git-sync@v2
         with:
           source_repo: "username/repository"
-          source_branch: "main"
           destination_repo: "git@github.com:org/repository.git"
-          destination_branch: "main"
+          source_branch: "main" # [regexp] optional, will sync all by default
+          destination_branch: "main" # [string] optional, will sync all by default
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }} # optional
           source_ssh_private_key: ${{ secrets.SOURCE_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
           destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
+          commit_user_email: ${{ secrets.COMMIT_USER_EMAIL }} # optional, will trigger 'git-sync' commit
+          commit_user_name: ${{ secrets.COMMIT_USER_NAME }} # optional, will trigger 'git-sync' commit
+          sync_tags: ${{ secrets.SYNC_TAGS }} # optional, will sync all tags
 ```
 
 ##### Alternative using https
@@ -59,29 +63,11 @@ The `ssh_private_key`, `source_ssh_private_key` and `destination_ssh_private_key
 source_repo: "https://username:personal_access_token@github.com/username/repository.git"
 ```
 
-#### Advanced: Sync all branches
-
-To Sync all branches from source to destination, use `source_branch: "refs/remotes/source/*"` and `destination_branch: "refs/heads/*"`. But be careful, branches with the same name including `master` will be overwritten.
-
-```yml
-source_branch: "refs/remotes/source/*"
-destination_branch: "refs/heads/*"
-```
-
-#### Advanced: Sync all tags
-
-To Sync all tags from source to destination, use `source_branch: "refs/tags/*"` and `destination_branch: "refs/tags/*"`. But be careful, tags with the same name will be overwritten.
-
-```yml
-source_branch: "refs/tags/*"
-destination_branch: "refs/tags/*"
-```
-
 ### Docker
 
 ```sh
 $ docker run --rm -e "SSH_PRIVATE_KEY=$(cat ~/.ssh/id_rsa)" $(docker build -q .) \
-  $SOURCE_REPO $SOURCE_BRANCH $DESTINATION_REPO $DESTINATION_BRANCH
+  $SOURCE_REPO $DESTINATION_REPO $SOURCE_BRANCH $DESTINATION_BRANCH
 ```
 
 ## Author

--- a/action.yml
+++ b/action.yml
@@ -8,15 +8,15 @@ inputs:
   source_repo:
     description: GitHub repo slug or full url
     required: true
-  source_branch:
-    description: Branch name to sync from
-    required: true
   destination_repo:
     description: GitHub repo slug or full url
     required: true
+  source_branch:
+    description: Branch name to sync from
+    required: false
   destination_branch:
     description: Branch name to sync to
-    required: true
+    required: false
   ssh_private_key:
     description: SSH key used to authenticate with source and destination ssh urls provided (optional if public or https url with authentication)
     required: false
@@ -26,6 +26,15 @@ inputs:
   destination_ssh_private_key:
     description: SSH key used to authenticate with destination ssh url provided (optional if public or https url with authentication)
     required: false
+  commit_user_email:
+    description: Email address used for sync commit
+    required: false
+  commit_user_name:
+    description: Name used for sync commit
+    required: false
+  sync_tags:
+    description: Sync tags
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -33,8 +42,11 @@ runs:
     SSH_PRIVATE_KEY: ${{ inputs.ssh_private_key }}
     SOURCE_SSH_PRIVATE_KEY: ${{ inputs.source_ssh_private_key }}
     DESTINATION_SSH_PRIVATE_KEY: ${{ inputs.destination_ssh_private_key }}
+    COMMIT_USER_EMAIL: ${{ inputs.commit_user_email }}
+    COMMIT_USER_NAME: ${{ inputs.commit_user_name }}
+    SYNC_TAGS: ${{ inputs.sync_tags }}
   args:
     - ${{ inputs.source_repo }}
-    - ${{ inputs.source_branch }}
     - ${{ inputs.destination_repo }}
+    - ${{ inputs.source_branch }}
     - ${{ inputs.destination_branch }}

--- a/action.yml
+++ b/action.yml
@@ -17,14 +17,18 @@ inputs:
   destination_branch:
     description: Branch name to sync to
     required: true
-  ssh_private_key:
-    description: SSH key used to authenticate with git clone urls provided (optional if public or https clone url with authentication)
+  source_ssh_private_key:
+    description: SSH key used to authenticate with source ssh clone url provided (optional if public or https clone url with authentication)
+    required: false
+  destination_ssh_private_key:
+    description: SSH key used to authenticate with destination ssh clone url provided (optional if public or https clone url with authentication)
     required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    SSH_PRIVATE_KEY: ${{ inputs.ssh_private_key }}
+    SOURCE_SSH_PRIVATE_KEY: ${{ inputs.source_ssh_private_key }}
+    DESTINATION_SSH_PRIVATE_KEY: ${{ inputs.destination_ssh_private_key }}
   args:
     - ${{ inputs.source_repo }}
     - ${{ inputs.source_branch }}

--- a/action.yml
+++ b/action.yml
@@ -1,32 +1,36 @@
 name: Git Sync Action
 author: Wei He <github@weispot.com>
-description: 🔃 Sync between two independent repositories
+description: 🔃  Sync between two independent repositories
 branding:
   icon: 'git-branch'
   color: 'gray-dark'
 inputs:
   source_repo:
-    description: GitHub repo slug or full clone url
+    description: GitHub repo slug or full url
     required: true
   source_branch:
     description: Branch name to sync from
     required: true
   destination_repo:
-    description: GitHub repo slug or full clone url
+    description: GitHub repo slug or full url
     required: true
   destination_branch:
     description: Branch name to sync to
     required: true
+  ssh_private_key:
+    description: SSH key used to authenticate with source and destination ssh urls provided (optional if public or https url with authentication)
+    required: false
   source_ssh_private_key:
-    description: SSH key used to authenticate with source ssh clone url provided (optional if public or https clone url with authentication)
+    description: SSH key used to authenticate with source ssh url provided (optional if public or https url with authentication)
     required: false
   destination_ssh_private_key:
-    description: SSH key used to authenticate with destination ssh clone url provided (optional if public or https clone url with authentication)
+    description: SSH key used to authenticate with destination ssh url provided (optional if public or https url with authentication)
     required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
+    SSH_PRIVATE_KEY: ${{ inputs.ssh_private_key }}
     SOURCE_SSH_PRIVATE_KEY: ${{ inputs.source_ssh_private_key }}
     DESTINATION_SSH_PRIVATE_KEY: ${{ inputs.destination_ssh_private_key }}
   args:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,14 +2,21 @@
 
 set -e
 
-if [[ -n "$SSH_PRIVATE_KEY" ]]
+if [[ -n "$SOURCE_SSH_PRIVATE_KEY" ]]
 then
   mkdir -p /root/.ssh
-  echo "$SSH_PRIVATE_KEY" > /root/.ssh/id_rsa
-  chmod 600 /root/.ssh/id_rsa
+  echo "$SOURCE_SSH_PRIVATE_KEY" | sed 's/\\n/\n/g' > /root/.ssh/src_id_rsa
+  chmod 600 /root/.ssh/src_id_rsa
+fi
+
+if [[ -n "$DESTINATION_SSH_PRIVATE_KEY" ]]
+then
+  mkdir -p /root/.ssh
+  echo "$DESTINATION_SSH_PRIVATE_KEY" | sed 's/\\n/\n/g' > /root/.ssh/dst_id_rsa
+  chmod 600 /root/.ssh/dst_id_rsa
 fi
 
 mkdir -p ~/.ssh
-cp /root/.ssh/* ~/.ssh/ 2> /dev/null || true 
+cp /root/.ssh/* ~/.ssh/ 2> /dev/null || true
 
 sh -c "/git-sync.sh $*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,21 +2,25 @@
 
 set -e
 
-if [[ -n "$SOURCE_SSH_PRIVATE_KEY" ]]
-then
+if [[ -n "$SSH_PRIVATE_KEY" ]]; then
   mkdir -p /root/.ssh
-  echo "$SOURCE_SSH_PRIVATE_KEY" | sed 's/\\n/\n/g' > /root/.ssh/src_id_rsa
-  chmod 600 /root/.ssh/src_id_rsa
+  echo "$SSH_PRIVATE_KEY" | sed 's/\\n/\n/g' >/root/.ssh/id_rsa
+  chmod 600 /root/.ssh/id_rsa
 fi
 
-if [[ -n "$DESTINATION_SSH_PRIVATE_KEY" ]]
-then
+if [[ -n "$SOURCE_SSH_PRIVATE_KEY" ]]; then
   mkdir -p /root/.ssh
-  echo "$DESTINATION_SSH_PRIVATE_KEY" | sed 's/\\n/\n/g' > /root/.ssh/dst_id_rsa
-  chmod 600 /root/.ssh/dst_id_rsa
+  echo "$SOURCE_SSH_PRIVATE_KEY" | sed 's/\\n/\n/g' >/root/.ssh/src_rsa
+  chmod 600 /root/.ssh/src_rsa
+fi
+
+if [[ -n "$DESTINATION_SSH_PRIVATE_KEY" ]]; then
+  mkdir -p /root/.ssh
+  echo "$DESTINATION_SSH_PRIVATE_KEY" | sed 's/\\n/\n/g' >/root/.ssh/dst_rsa
+  chmod 600 /root/.ssh/dst_rsa
 fi
 
 mkdir -p ~/.ssh
-cp /root/.ssh/* ~/.ssh/ 2> /dev/null || true
+cp /root/.ssh/* ~/.ssh/ 2>/dev/null || true
 
 sh -c "/git-sync.sh $*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,4 +23,4 @@ fi
 mkdir -p ~/.ssh
 cp /root/.ssh/* ~/.ssh/ 2>/dev/null || true
 
-sh -c "/git-sync.sh $*"
+bash -c "/git-sync.sh $*"

--- a/git-sync.sh
+++ b/git-sync.sh
@@ -9,7 +9,7 @@ DESTINATION_BRANCH=$4
 
 if ! echo $SOURCE_REPO | grep -Eq ':|@|\.git\/?$'
 then
-  if [[ -n "$SSH_PRIVATE_KEY" ]]
+  if [[ -n "$SOURCE_SSH_PRIVATE_KEY" ]]
   then
     SOURCE_REPO="git@github.com:${SOURCE_REPO}.git"
     GIT_SSH_COMMAND="ssh -v"
@@ -19,7 +19,7 @@ then
 fi
 if ! echo $DESTINATION_REPO | grep -Eq ':|@|\.git\/?$'
 then
-  if [[ -n "$SSH_PRIVATE_KEY" ]]
+  if [[ -n "$DESTINATION_SSH_PRIVATE_KEY" ]]
   then
     DESTINATION_REPO="git@github.com:${DESTINATION_REPO}.git"
     GIT_SSH_COMMAND="ssh -v"
@@ -31,7 +31,14 @@ fi
 echo "SOURCE=$SOURCE_REPO:$SOURCE_BRANCH"
 echo "DESTINATION=$DESTINATION_REPO:$DESTINATION_BRANCH"
 
-git clone "$SOURCE_REPO" /root/source --origin source && cd /root/source
+if [[ -n "$SOURCE_SSH_PRIVATE_KEY" ]]
+then
+  # Clone using source ssh key
+  git clone -c core.sshCommand="/usr/bin/ssh -i ~/.ssh/src_id_rsa" "$SOURCE_REPO" /root/source --origin source && cd /root/source
+else
+  git clone "$SOURCE_REPO" /root/source --origin source && cd /root/source
+fi
+
 git remote add destination "$DESTINATION_REPO"
 
 # Pull all branches references down locally so subsequent commands can see them
@@ -39,5 +46,11 @@ git fetch source '+refs/heads/*:refs/heads/*' --update-head-ok
 
 # Print out all branches
 git --no-pager branch -a -vv
+
+if [[ -n "$DESTINATION_SSH_PRIVATE_KEY" ]]
+then
+  # Push using destination ssh key
+  git config --local core.sshCommand "/usr/bin/ssh -i ~/.ssh/dst_id_rsa"
+fi
 
 git push destination "${SOURCE_BRANCH}:${DESTINATION_BRANCH}" -f

--- a/git-sync.sh
+++ b/git-sync.sh
@@ -7,20 +7,17 @@ SOURCE_BRANCH=$2
 DESTINATION_REPO=$3
 DESTINATION_BRANCH=$4
 
-if ! echo $SOURCE_REPO | grep -Eq ':|@|\.git\/?$'
-then
-  if [[ -n "$SOURCE_SSH_PRIVATE_KEY" ]]
-  then
+if ! echo $SOURCE_REPO | grep -Eq ':|@|\.git\/?$'; then
+  if [[ -n "$SSH_PRIVATE_KEY" || -n "$SOURCE_SSH_PRIVATE_KEY" ]]; then
     SOURCE_REPO="git@github.com:${SOURCE_REPO}.git"
     GIT_SSH_COMMAND="ssh -v"
   else
     SOURCE_REPO="https://github.com/${SOURCE_REPO}.git"
   fi
 fi
-if ! echo $DESTINATION_REPO | grep -Eq ':|@|\.git\/?$'
-then
-  if [[ -n "$DESTINATION_SSH_PRIVATE_KEY" ]]
-  then
+
+if ! echo $DESTINATION_REPO | grep -Eq ':|@|\.git\/?$'; then
+  if [[ -n "$SSH_PRIVATE_KEY" || -n "$DESTINATION_SSH_PRIVATE_KEY" ]]; then
     DESTINATION_REPO="git@github.com:${DESTINATION_REPO}.git"
     GIT_SSH_COMMAND="ssh -v"
   else
@@ -31,10 +28,9 @@ fi
 echo "SOURCE=$SOURCE_REPO:$SOURCE_BRANCH"
 echo "DESTINATION=$DESTINATION_REPO:$DESTINATION_BRANCH"
 
-if [[ -n "$SOURCE_SSH_PRIVATE_KEY" ]]
-then
-  # Clone using source ssh key
-  git clone -c core.sshCommand="/usr/bin/ssh -i ~/.ssh/src_id_rsa" "$SOURCE_REPO" /root/source --origin source && cd /root/source
+if [[ -n "$SOURCE_SSH_PRIVATE_KEY" ]]; then
+  # Clone using source ssh key if provided
+  git clone -c core.sshCommand="/usr/bin/ssh -i ~/.ssh/src_rsa" "$SOURCE_REPO" /root/source --origin source && cd /root/source
 else
   git clone "$SOURCE_REPO" /root/source --origin source && cd /root/source
 fi
@@ -47,10 +43,9 @@ git fetch source '+refs/heads/*:refs/heads/*' --update-head-ok
 # Print out all branches
 git --no-pager branch -a -vv
 
-if [[ -n "$DESTINATION_SSH_PRIVATE_KEY" ]]
-then
-  # Push using destination ssh key
-  git config --local core.sshCommand "/usr/bin/ssh -i ~/.ssh/dst_id_rsa"
+if [[ -n "$DESTINATION_SSH_PRIVATE_KEY" ]]; then
+  # Push using destination ssh key if provided
+  git config --local core.sshCommand "/usr/bin/ssh -i ~/.ssh/dst_rsa"
 fi
 
 git push destination "${SOURCE_BRANCH}:${DESTINATION_BRANCH}" -f


### PR DESCRIPTION
This PR supersedes my last one 😄 

It may go a little far from the original and probably too much of a breaking change.

I realised that I needed the synced commits to use a particular author email in order to be compatible with my deployment pipeline.

Basically this change now allows you to specify an email/name which will then trigger a "sync" commit.

While I was at it I added support for a regexp in the `SOURCE_BRANCH` and made the action sync everything by default.

Totally understand if this goes too far - I can maintain a fork for my needs...

Thanks!