### PR TITLE
docs: destination_repo should not end with `.git`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
         with:
           source_repo: "source_org/repository"
           source_branch: "main"
-          destination_repo: "destination_org/repository.git"
+          destination_repo: "destination_org/repository"
           destination_branch: "main"
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }} # optional
           source_ssh_private_key: ${{ secrets.SOURCE_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`


### PR DESCRIPTION
Refs: https://github.com/wei/git-sync/issues/25#issuecomment-768415966